### PR TITLE
Accept content type json with empty body.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -556,6 +556,9 @@ class Offline {
             const contentTypesThatRequirePayloadParsing = ['application/json', 'application/vnd.api+json'];
             if (contentTypesThatRequirePayloadParsing.indexOf(contentType) !== -1) {
               try {
+                if (!request.payload || request.payload.length < 1) {
+                  request.payload = '{}';
+                }
                 request.payload = JSON.parse(request.payload);
               }
               catch (err) {


### PR DESCRIPTION
I ran into this issue when trying to send a POST request with an empty body, arguably serverless-offline crashing so early is a good thing, but I would rather handle these cases myself. 